### PR TITLE
Run Unbind/Bind VF in a serial manner.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/containernetworking/cni v0.7.1
 	github.com/containernetworking/plugins v0.8.5
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/gofrs/flock v0.7.1
 	github.com/onsi/ginkgo v1.12.0
 	github.com/onsi/gomega v1.9.0
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -27,6 +27,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/godbus/dbus v0.0.0-20180201030542-885f9cc04c9c/go.mod h1:/YcGZj5zSblfDWMMoOzV4fas9FZnQYTkDnsGvmh2Grw=
+github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
+github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1 h1:YF8+flBXS5eO826T4nzqPrxfhQThhXl0YzfuUPu4SBg=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -15,6 +15,10 @@ import (
 var (
 	// DefaultCNIDir used for caching NetConf
 	DefaultCNIDir = "/var/lib/cni/ib-sriov-cni"
+	// CniFileLockDir point to the CNI's lockfile
+	CniFileLockDir = "/var/run/cni/ib-sriov-cni"
+	// CniFileLockName is the name of the lockfile used in the CNI
+	CniFileLockName = "cni.lock"
 )
 
 // LoadConf parses and validates stdin netconf and returns NetConf object


### PR DESCRIPTION
Unbind/Bind VF as well as moving RDMA device to namespace
causes rdma resources to be re-created.
CNI may be invoked in parallel and kernel may provide a VF
RDMA resources under a different name.

As the mapping of RDMA resources is done in Device plugin
prior to CNI invocation, it must not change during CNI invocation.

We serialize the CNI's Add,Del operations by Creating/Locking/Unlocking
a file, causing kernel to allocate RDMA resources the same name
for a given VF.

In the future, Systems should use udev PCI based RDMA device
names, ensuring consistent RDMA resources names.