### PR TITLE
update golang version to 1.13 in Dockerfile.rhel7

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.10 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.13 AS builder
 
 COPY . /usr/src/ib-sriov-cni
 


### PR DESCRIPTION
make clean fails with golang-1.10:
"flag provided but not defined: -modcache"