### PR TITLE
Skip guid config if no guid passed in the conf

### DIFF
--- a/cmd/ib-sriov-cni/main.go
+++ b/cmd/ib-sriov-cni/main.go
@@ -38,18 +38,18 @@ func init() {
 	runtime.LockOSThread()
 }
 
-func getGUIDFromConf(netConf *localtypes.NetConf) (string, error) {
+func getGUIDFromConf(netConf *localtypes.NetConf) string {
 	// Take from runtime config if available
 	if netConf.RuntimeConfig.InfinibandGUID != "" {
-		return netConf.RuntimeConfig.InfinibandGUID, nil
+		return netConf.RuntimeConfig.InfinibandGUID
 	}
 	// Take from CNI_ARGS if available
 	if guid, ok := netConf.Args.CNI["guid"]; ok {
-		return guid, nil
+		return guid
 	}
 
-	return "", fmt.Errorf(
-		"infiniBand SRIOV-CNI failed, no guid found from runtimeConfig/CNI_ARGS, please check mellanox ib-kubernets")
+	// No guid provided
+	return ""
 }
 
 func lockCNIExecution() (*flock.Flock, error) {
@@ -100,9 +100,7 @@ func cmdAdd(args *skel.CmdArgs) error {
 			infiniBandAnnotation, configuredInfiniBand)
 	}
 
-	if netConf.GUID, err = getGUIDFromConf(netConf); err != nil {
-		return err
-	}
+	netConf.GUID = getGUIDFromConf(netConf)
 
 	if netConf.RdmaIso {
 		err = utils.EnsureRdmaSystemMode()

--- a/pkg/sriov/sriov.go
+++ b/pkg/sriov/sriov.go
@@ -231,20 +231,22 @@ func (s *sriovManager) ApplyVFConfig(conf *types.NetConf) error {
 	}
 
 	// Set link guid
-	if !utils.IsValidGUID(conf.GUID) {
-		return fmt.Errorf("invalid guid %s", conf.GUID)
-	}
-	// save link guid
-	vfLink, err := s.nLink.LinkByName(conf.HostIFNames)
-	if err != nil {
-		return fmt.Errorf("failed to lookup vf %q: %v", conf.HostIFNames, err)
-	}
+	if conf.GUID != "" {
+		if !utils.IsValidGUID(conf.GUID) {
+			return fmt.Errorf("invalid guid %s", conf.GUID)
+		}
+		// save link guid
+		vfLink, err := s.nLink.LinkByName(conf.HostIFNames)
+		if err != nil {
+			return fmt.Errorf("failed to lookup vf %q: %v", conf.HostIFNames, err)
+		}
 
-	conf.HostIFGUID = vfLink.Attrs().HardwareAddr.String()[36:]
+		conf.HostIFGUID = vfLink.Attrs().HardwareAddr.String()[36:]
 
-	// Set link guid
-	if err := s.setVfGUID(conf, pfLink, conf.GUID); err != nil {
-		return err
+		// Set link guid
+		if err := s.setVfGUID(conf, pfLink, conf.GUID); err != nil {
+			return err
+		}
 	}
 
 	return nil
@@ -270,12 +272,12 @@ func (s *sriovManager) ResetVFConfig(conf *types.NetConf) error {
 	// Reset link guid
 	// if the host guid is all zeros which is invalid guid replace it with all F guid
 	// This happen when create a VF it guid is all zeros
-	if utils.IsAllZeroGUID(conf.HostIFGUID) {
-		conf.HostIFGUID = "FF:FF:FF:FF:FF:FF:FF:FF"
-	}
+	if conf.HostIFGUID != "" {
+		if utils.IsAllZeroGUID(conf.HostIFGUID) {
+			conf.HostIFGUID = "FF:FF:FF:FF:FF:FF:FF:FF"
+		}
 
-	if err := s.setVfGUID(conf, pfLink, conf.HostIFGUID); err != nil {
-		return err
+		return s.setVfGUID(conf, pfLink, conf.HostIFGUID)
 	}
 
 	return nil

--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -102,6 +102,19 @@ var _ = Describe("Sriov", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(netconf.HostIFGUID).To(Equal(hostGUID))
 		})
+		It("ApplyVFConfig without GUID", func() {
+			mockedNetLinkManger := &mocks.NetlinkManager{}
+			mockedPciUtils := &mocks.PciUtils{}
+
+			fakeLink := &FakeLink{}
+			mockedNetLinkManger.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
+
+			sm := sriovManager{nLink: mockedNetLinkManger, utils: mockedPciUtils}
+			err := sm.ApplyVFConfig(netconf)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(netconf.HostIFGUID).To(Equal(""))
+			Expect(netconf.GUID).To(Equal(""))
+		})
 		It("ApplyVFConfig with invalid GUID - wrong characters", func() {
 			mockedNetLinkManger := &mocks.NetlinkManager{}
 
@@ -455,6 +468,17 @@ var _ = Describe("Sriov", func() {
 			mockedNetLinkManger.On("LinkSetVfPortGUID", fakeLink, mock.AnythingOfType("int"), mock.Anything).Return(nil)
 
 			mockedPciUtils.On("RebindVf", mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil)
+
+			sm := sriovManager{nLink: mockedNetLinkManger, utils: mockedPciUtils}
+			err := sm.ResetVFConfig(netconf)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		It("ResetVFConfig without GUID", func() {
+			mockedNetLinkManger := &mocks.NetlinkManager{}
+			mockedPciUtils := &mocks.PciUtils{}
+
+			fakeLink := &FakeLink{netlink.LinkAttrs{}}
+			mockedNetLinkManger.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 
 			sm := sriovManager{nLink: mockedNetLinkManger, utils: mockedPciUtils}
 			err := sm.ResetVFConfig(netconf)


### PR DESCRIPTION
Prevent cni failing if no guid pass and skip guid configuring which
supports deployments that rely on GUIDs being pre configured on the
VF e.g not using ib-kubernetes to allocate guids and want to allow CNI
to set up the VF without GUID configuration
