### PR TITLE
Validate GUID was provided when ib-kubernetes is enabled

### DIFF
--- a/cmd/ib-sriov-cni/main.go
+++ b/cmd/ib-sriov-cni/main.go
@@ -109,6 +109,11 @@ func cmdAdd(args *skel.CmdArgs) error {
 
 	netConf.GUID = getGUIDFromConf(netConf)
 
+	// Ensure GUID was provided if ib-kubernetes integration is enabled
+	if netConf.IBKubernetesEnabled && netConf.GUID == "" {
+		return fmt.Errorf("infiniband SRIOV-CNI failed, Unexpected error. GUID must be provided by ib-kubernetes")
+	}
+
 	if netConf.RdmaIso {
 		err = utils.EnsureRdmaSystemMode()
 		if err != nil {


### PR DESCRIPTION
When ib-kubernetes integration is enabled, it is expected
that GUID is provided in network configurations in either:

1. "guid" CNI Arg
2. "infinibandGUID" Runtime config

Fail in the unlikely case where none of the above is present.

Signed-off-by: Adrian Chiris <adrianc@mellanox.com>