### PR TITLE
pkg/sriov: Restore VF name after rebinding

### DIFF
--- a/pkg/sriov/sriov_test.go
+++ b/pkg/sriov/sriov_test.go
@@ -503,6 +503,7 @@ var _ = Describe("Sriov", func() {
 			fakeLink := &FakeLink{netlink.LinkAttrs{}}
 			netconf.HostIFGUID = "01:23:45:67:89:ab:cd:ef"
 
+			mockedNetLinkManger.On("LinkSetName", fakeLink, netconf.HostIFNames).Return(nil)
 			mockedNetLinkManger.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 			mockedNetLinkManger.On("LinkSetVfNodeGUID", fakeLink, mock.AnythingOfType("int"), mock.Anything).Return(nil)
 			mockedNetLinkManger.On("LinkSetVfPortGUID", fakeLink, mock.AnythingOfType("int"), mock.Anything).Return(nil)
@@ -531,6 +532,7 @@ var _ = Describe("Sriov", func() {
 			fakeLink := &FakeLink{netlink.LinkAttrs{}}
 			netconf.HostIFGUID = "00:00:00:00:00:00:00:00"
 
+			mockedNetLinkManger.On("LinkSetName", fakeLink, netconf.HostIFNames).Return(nil)
 			mockedNetLinkManger.On("LinkByName", mock.AnythingOfType("string")).Return(fakeLink, nil)
 			mockedNetLinkManger.On("LinkSetVfNodeGUID", fakeLink, mock.AnythingOfType("int"), mock.Anything).Return(nil)
 			mockedNetLinkManger.On("LinkSetVfPortGUID", fakeLink, mock.AnythingOfType("int"), mock.Anything).Return(nil)


### PR DESCRIPTION
Due to kernel driver constraints, on cmdDel the plugin is required to rebind the VF
in order to restore the VF's GUID value.
During VF rebind the kernel may assign the VF netdev a new name from predefined scheme, which can differs from its initial name that the plugin caches.
This may cause conflicts with other VFs that are currently cached and processed by plugin.
For example:
Two pods were created:
- Pod A with <vf0> and corresponding netdev `ib0`.
- Pod B with <vf1> and corresponding netdev  `ib1`.
 
If pod B is deleted first, then after GUID value is restored (driver rebind occurs) it will get the netdev name `ib0`.
This causes the plugin to fail on Pod A pod deletion, when, on `CmdDel`, it tries to move
<vf0> netdev to the host netns, since its cached (original) name `ib0' already exist.

We fix that by restoring initial name from the cached config after VF rebinding.

Fix: #51